### PR TITLE
Update the order of some commands

### DIFF
--- a/docs/Installation/getting-started.md
+++ b/docs/Installation/getting-started.md
@@ -96,7 +96,6 @@ cd /var/www/controlpanel
 
 ```bash
 git clone https://github.com/ControlPanel-gg/dashboard.git ./
-chmod -R 755 storage/* bootstrap/cache/
 ```
 
 ## Basic Setup
@@ -117,24 +116,6 @@ CREATE DATABASE controlpanel;
 CREATE USER 'controlpaneluser'@'127.0.0.1' IDENTIFIED BY 'USE_YOUR_OWN_PASSWORD';
 GRANT ALL PRIVILEGES ON controlpanel.* TO 'controlpaneluser'@'127.0.0.1';
 FLUSH PRIVILEGES;
-```
-
-### Set Permissions
-
-The last step in the installation process is to set the correct permissions on the Panel files so that the webserver can
-use them correctly.
-
-```bash
-# If using NGINX or Apache (not on CentOS):
-chown -R www-data:www-data /var/www/controlpanel/
-
-# If using NGINX on CentOS:
-chown -R nginx:nginx /var/www/controlpanel/
-
-# If using Apache on CentOS
-chown -R apache:apache /var/www/controlpanel/
-
-****
 ```
 
 ## Webserver Configuration
@@ -200,6 +181,27 @@ For this navigate into your `/var/www/controlpanel` again and run the following 
 
 ```bash
 composer install --no-dev --optimize-autoloader
+```
+
+### Set Permissions
+
+The last step in the installation process is to set the correct permissions on the Panel files so that the webserver can
+use them correctly.
+
+```bash
+# If using NGINX or Apache (not on CentOS):
+chown -R www-data:www-data /var/www/controlpanel/
+chmod -R 755 storage/* bootstrap/cache/
+
+# If using NGINX on CentOS:
+chown -R nginx:nginx /var/www/controlpanel/
+chmod -R 755 storage/* bootstrap/cache/
+
+# If using Apache on CentOS
+chown -R apache:apache /var/www/controlpanel/
+chmod -R 755 storage/* bootstrap/cache/
+
+****
 ```
 
 Once this is done, you should be able to access the dashboard via your webbrowser.


### PR DESCRIPTION
## Motive
Following the original documentation, one of the last steps is the composer installation command for the panel.
`composer install --no-dev --optimize-autoloader`
Following this, you will have already given the permissions for the directories and permissions for the web-server to get everything working.

## Problem
As stated above, if you give the required permissions, and then you install `composer`, you will get a permissions error in the `.env` configuration step.
I believe this is because you have already given the necessary permissions.
But installing composer seems to need the same permissions.
And since the order is reversed, the permissions don't exist.
This causes the problem in the image below that many people have.
![1](https://user-images.githubusercontent.com/69549678/158065502-e23600ce-cd98-4056-9ce5-2c6e2b5f93c8.png)

## Solution
The solution is simple, just override the order of permissions and install `composer`.
This PR already does that.
